### PR TITLE
Update btn-link classes and wording

### DIFF
--- a/blklot-lookup/blklot-lookup.json
+++ b/blklot-lookup/blklot-lookup.json
@@ -745,12 +745,12 @@
             "id": "elfmeek"
           },
           {
-            "label": "Enter the block and lot number instead.",
+            "label": "Enter the block and lot number instead",
             "action": "custom",
             "showValidations": false,
             "theme": "secondary",
             "size": "sm",
-            "customClass": "btn-link h5",
+            "customClass": "btn-link p-0",
             "tableView": false,
             "key": "enterBlockAndLotInstead",
             "type": "button",
@@ -1559,12 +1559,12 @@
             "id": "epohq"
           },
           {
-            "label": "Enter address instead.",
+            "label": "Enter the address instead",
             "action": "custom",
             "showValidations": false,
             "theme": "secondary",
             "size": "sm",
-            "customClass": "btn-link h5",
+            "customClass": "btn-link p-0",
             "tableView": false,
             "key": "enterByAddressInstead",
             "type": "button",


### PR DESCRIPTION
Two changes here:
1. I've replaced the `h5` class that accompanied `btn-link` with `p-0` to shrink the font size down and remove padding so that it aligns with the rest of the content and the buttons below:

    Before | After
    :--- | :---
    ![image](https://user-images.githubusercontent.com/113896/126531699-a6f54c8d-2887-4289-926c-a08e1f670424.png) | ![image](https://user-images.githubusercontent.com/113896/126531743-c174e3ff-6a7d-46b2-91e9-ca72952ba086.png)

2. I've removed the periods at the ends of both button texts ("Enter the block and lot number instead<s>.</s>") and added a "the" to "Enter **the** address instead<s>.</s>".